### PR TITLE
fix: sticky header init rendered rows is hidden partially

### DIFF
--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -118,6 +118,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     if (Math.abs(rowsScrolled) < rowSensitivity) {
       this.viewport.setRenderedContentOffset(renderedOffset);
       this.viewport.setRenderedRange({start, end});
+      this.stickyChange.next(renderedOffset);
       return;
     }
 
@@ -127,6 +128,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     if (renderedOffset === 0 && rowsScrolled < 0) {
       this.viewport.setRenderedContentOffset(renderedOffset);
       this.viewport.setRenderedRange({start, end});
+      this.stickyChange.next(0);
       return;
     }
 

--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -71,7 +71,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     if (!this.viewport || !this.rowHeight) {
       return;
     }
-    this.viewport.scrollToOffset((index - 1 ) * this.rowHeight + this.headerHeight, behavior);
+    this.viewport.scrollToOffset(index * this.rowHeight, behavior);
   }
 
   public setConfig(configs: TSVStrategyConfigs) {

--- a/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
@@ -1,6 +1,7 @@
+import { VIRTUAL_SCROLL_STRATEGY } from '@angular/cdk/scrolling';
+import { CdkHeaderRowDef } from '@angular/cdk/table';
 import {
-  AfterContentInit,
-  ContentChild,
+  AfterContentInit, ContentChild,
   Directive,
   forwardRef,
   Input,
@@ -8,13 +9,11 @@ import {
   OnChanges,
   OnDestroy
 } from '@angular/core';
-import { VIRTUAL_SCROLL_STRATEGY } from '@angular/cdk/scrolling';
-import { delayWhen, distinctUntilChanged, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { TableVirtualScrollDataSource } from './table-data-source';
 import { MatTable } from '@angular/material/table';
+import { Subject } from 'rxjs';
+import { distinctUntilChanged, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { FixedSizeTableVirtualScrollStrategy } from './fixed-size-table-virtual-scroll-strategy';
-import { CdkHeaderRowDef } from '@angular/cdk/table';
-import { of, Subject, timer } from 'rxjs';
+import { TableVirtualScrollDataSource } from './table-data-source';
 
 export function _tableVirtualScrollDirectiveStrategyFactory(tableDir: TableItemSizeDirective) {
   return tableDir.scrollStrategy;
@@ -98,7 +97,6 @@ export class TableItemSizeDirective implements OnChanges, AfterContentInit, OnDe
     this.scrollStrategy.stickyChange
       .pipe(
         filter(() => this.isStickyEnabled()),
-        delayWhen(() => !this.stickyPositions ? timer(0) : of()),
         tap(() => {
           if (!this.stickyPositions) {
             this.initStickyPositions();
@@ -126,9 +124,9 @@ export class TableItemSizeDirective implements OnChanges, AfterContentInit, OnDe
               .renderedRangeStream
               .pipe(
                 map(({
-                       start,
-                       end
-                     }) => typeof start !== 'number' || typeof end !== 'number' ? data : data.slice(start, end))
+                  start,
+                  end
+                }) => typeof start !== 'number' || typeof end !== 'number' ? data : data.slice(start, end))
               )
           )
         )


### PR DESCRIPTION
hey - we have a table where we have the header e.g. 64px height, and the rows 32px height. initially the scrolling is perfect, but as soon as we load new items, and we scroll upwards from the bottom of the table, the header is just the half of it visible, so I set the offset to zero in this case, and at every other scrolling I set it to the offsetRenderer which was before.

let me know if it does break anything for you.

And thanks for your contribution to the origin lib!